### PR TITLE
Make shellcheck return code matter

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 main() {
   "$WERCKER_STEP_ROOT"/shellcheck -V
 


### PR DESCRIPTION
Without "set -e", this wercker-step will always pass.